### PR TITLE
Return RAW XML to the session result if the required data type is string

### DIFF
--- a/src/Wps/Wps.Client/Models/ResultOutput.cs
+++ b/src/Wps/Wps.Client/Models/ResultOutput.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml;
+﻿using System;
+using System.Xml;
 using System.Xml.Schema;
 using System.Xml.Serialization;
 using Wps.Client.Services;
@@ -47,7 +48,14 @@ namespace Wps.Client.Models
                     if (subtreeReader.LocalName.Equals("Data"))
                     {
                         var content = subtreeReader.ReadInnerXml();
-                        Data = serializer.Deserialize<TData>(content);
+                        if (typeof(TData) == typeof(string))
+                        {
+                            Data = (TData) Convert.ChangeType(content, typeof(string));
+                        }
+                        else
+                        {
+                            Data = serializer.Deserialize<TData>(content);
+                        }
                     }
 
                     if (subtreeReader.LocalName.Equals("Output"))

--- a/src/Wps/Wps.Client/Wps.Client.csproj
+++ b/src/Wps/Wps.Client/Wps.Client.csproj
@@ -1,7 +1,31 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <Authors>Mihai Stan, Benjamin Pross</Authors>
+    <Company>52°North</Company>
+    <Product>WPS Library</Product>
+    <Description>This is a library that allows developers to speed up their development when working with WPS providers.</Description>
+    <RepositoryUrl>https://github.com/52North/wps.net</RepositoryUrl>
+    <PackageTags>wps library client</PackageTags>
+    <PackageProjectUrl>https://github.com/52North/wps.net</PackageProjectUrl>
+    <PackageLicenseExpression></PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageId>Wps.Net</PackageId>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="Extensions\" />
+    <Folder Include="Exceptions\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\..\LICENSE">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/Wps/Wps.Client/Wps.Client.csproj
+++ b/src/Wps/Wps.Client/Wps.Client.csproj
@@ -14,6 +14,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageId>Wps.Net</PackageId>
+    <Version>1.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
If the user is willing to get the result as string then the appropriate action would be to return the XML string returned from the WPS provider, rather than attempting to deserialize the answer into a string.